### PR TITLE
Align translation keys across languages

### DIFF
--- a/assets/js/translations.en.js
+++ b/assets/js/translations.en.js
@@ -28,7 +28,11 @@ window.translations_en = {
   },
 
   innkjop: {
-    subtitle: "Useful links related to purchasing, orders, and approved suppliers."
+    title: "TODO: translate",
+    subtitle: "Useful links related to purchasing, orders, and approved suppliers.",
+    link1: "TODO: translate",
+    link2: "TODO: translate",
+    link3: "TODO: translate"
   },
 
   fresh: {
@@ -46,31 +50,43 @@ window.translations_en = {
 
   tips: {
     title: "💡 Tips and Resources in Freshservice",
-    subtitle: "Need help, an overview or want to suggest improvements? You’ll find guides, catalogs, and feedback options here.",
-    manuals: "📘 Manuals and Troubleshooting",
-    manuals_text: "Browse guides and support articles in Freshservice.",
-    language: "🌍 Change Language",
+    intro: "TODO: translate",
+    manual_title: "📘 Manuals and Troubleshooting",
+    manual_text: "Browse guides and support articles in Freshservice.",
+    language_title: "🌍 Change Language",
     language_text: "Guide to switch Freshservice to English, Norwegian or Swedish.",
-    katalog: "📁 Service Catalog",
-    katalog_text: "Browse internal services within logistics, IT, product and more.",
-    forbedringer: "🔧 Suggestions for Improvement",
-    forbedringer_text: "Have a suggestion to improve Freshservice? Register it here."
+    catalog_title: "📁 Service Catalog",
+    catalog_text: "Browse internal services within logistics, IT, product and more.",
+    improve_title: "🔧 Suggestions for Improvement",
+    improve_text: "Have a suggestion to improve Freshservice? Register it here."
   },
 
   mail: {
-    subtitle: "Quick access to email and calendar for efficient communication."
+    title: "TODO: translate",
+    subtitle: "Quick access to email and calendar for efficient communication.",
+    outlook: "TODO: translate",
+    calendar: "TODO: translate"
   },
 
   nyheter: {
+    title: "TODO: translate",
     subtitle: "Overview of internal news and information channels from Alligo – stay up to date on operations, products and initiatives.",
+    link1_title: "TODO: translate",
     link1_text: "Official news, product launches and press releases.",
+    link2_title: "TODO: translate",
     link2_text: "System status and internal tool updates.",
+    link3_title: "TODO: translate",
     link3_text: "Changes in product assortment, suppliers and launches.",
+    link4_title: "TODO: translate",
     link4_text: "New product innovations in the F-series – updated daily with direct links to articles."
   },
 
   opto: {
-    subtitle: "Here you'll find selected reports and statistics from Opto – available as Excel files."
+    title: "TODO: translate",
+    subtitle: "Here you'll find selected reports and statistics from Opto – available as Excel files.",
+    link1: "TODO: translate",
+    link2: "TODO: translate",
+    link3: "TODO: translate"
   },
 
   footer: {

--- a/assets/js/translations.no.js
+++ b/assets/js/translations.no.js
@@ -28,7 +28,10 @@ window.translations_no = {
   
     innkjop: {
       title: "🛒 Innkjøp",
-      subtitle: "Nyttige lenker knyttet til innkjøp, bestillinger og godkjente leverandører."
+      subtitle: "Nyttige lenker knyttet til innkjøp, bestillinger og godkjente leverandører.",
+      link1: "📦 Bestillingsportal for kontorutstyr",
+      link2: "✅ Godkjente leverandører",
+      link3: "🛠️ Rutine for bestilling av teknisk utstyr"
     },
   
     fresh: {
@@ -47,15 +50,15 @@ window.translations_no = {
     tips: {
       title: "💡 Tips og ressurser i Freshservice",
       intro: "Trenger du hjelp, oversikt eller har et forslag? Her finner du guider, forbedringer og tjenestekatalogen samlet på ett sted.",
-      manuals_title: "📘 Manualer og feilsøking",
-      manuals_text: "Se løsninger og brukerveiledning i Freshservice.",
+      manual_title: "📘 Manualer og feilsøking",
+      manual_text: "Se løsninger og brukerveiledning i Freshservice.",
       language_title: "🌍 Endre språk",
       language_text: "Guide til hvordan du tilpasser Freshservice til norsk, svensk eller engelsk.",
-      katalog_title: "📁 Tjenestekatalog",
-      katalog_text: "Se interne tjenester innen logistikk, IT, produkt og mer.",
-      forbedringer_title: "🔧 Funksjonsforbedringer",
-      forbedringer_text: "Har du forslag til forbedringer i Freshservice? Registrer dem her."
-    },
+      catalog_title: "📁 Tjenestekatalog",
+      catalog_text: "Se interne tjenester innen logistikk, IT, produkt og mer.",
+      improve_title: "🔧 Funksjonsforbedringer",
+      improve_text: "Har du forslag til forbedringer i Freshservice? Registrer dem her."
+   },
   
     mail: {
       title: "📧 E-post og kalender",

--- a/assets/js/translations.se.js
+++ b/assets/js/translations.se.js
@@ -28,7 +28,11 @@ window.translations_se = {
   },
 
   innkjop: {
-    subtitle: "Nyttiga länkar relaterade till inköp, beställningar och godkända leverantörer."
+    title: "TODO: translate",
+    subtitle: "Nyttiga länkar relaterade till inköp, beställningar och godkända leverantörer.",
+    link1: "TODO: translate",
+    link2: "TODO: translate",
+    link3: "TODO: translate"
   },
 
   fresh: {
@@ -46,31 +50,43 @@ window.translations_se = {
 
   tips: {
     title: "💡 Tips och resurser i Freshservice",
-    subtitle: "Behöver du hjälp, översikt eller har ett förbättringsförslag? Här finns guider, förbättringar och tjänstekatalogen samlade.",
-    manuals: "📘 Manualer och felsökning",
-    manuals_text: "Se lösningar och användarguider i Freshservice.",
-    language: "🌍 Ändra språk",
+    intro: "TODO: translate",
+    manual_title: "📘 Manualer och felsökning",
+    manual_text: "Se lösningar och användarguider i Freshservice.",
+    language_title: "🌍 Ändra språk",
     language_text: "Guide för att anpassa Freshservice till svenska, norska eller engelska.",
-    katalog: "📁 Tjänstekatalog",
-    katalog_text: "Se interna tjänster inom logistik, IT, produkt m.m.",
-    forbedringer: "🔧 Förbättringsförslag",
-    forbedringer_text: "Har du ett förslag för att förbättra Freshservice? Registrera det här."
+    catalog_title: "📁 Tjänstekatalog",
+    catalog_text: "Se interna tjänster inom logistik, IT, produkt m.m.",
+    improve_title: "🔧 Förbättringsförslag",
+    improve_text: "Har du ett förslag för att förbättra Freshservice? Registrera det här."
   },
 
   mail: {
-    subtitle: "Snabb åtkomst till e-post och kalender för effektiv kommunikation."
+    title: "TODO: translate",
+    subtitle: "Snabb åtkomst till e-post och kalender för effektiv kommunikation.",
+    outlook: "TODO: translate",
+    calendar: "TODO: translate"
   },
 
   nyheter: {
+    title: "TODO: translate",
     subtitle: "Samlad översikt över interna nyheter och informationskanaler från Alligo – håll dig uppdaterad om drift, sortiment och fältbaserade initiativ.",
+    link1_title: "TODO: translate",
     link1_text: "Officiella nyheter, lanseringar och pressmeddelanden.",
+    link2_title: "TODO: translate",
     link2_text: "Status och uppdateringar om system och interna verktyg.",
+    link3_title: "TODO: translate",
     link3_text: "Förändringar i produktsortiment, leverantörer och lanseringar.",
+    link4_title: "TODO: translate",
     link4_text: "Nya produktinnovationer i F-serien – listan uppdateras dagligen med direkta länkar till artiklarna."
   },
 
   opto: {
-    subtitle: "Här hittar du utvalda rapporter och statistik från Opto – tillgängliga som Excel-filer."
+    title: "TODO: translate",
+    subtitle: "Här hittar du utvalda rapporter och statistik från Opto – tillgängliga som Excel-filer.",
+    link1: "TODO: translate",
+    link2: "TODO: translate",
+    link3: "TODO: translate"
   },
 
   footer: {


### PR DESCRIPTION
## Summary
- sync translation keys across Norwegian, Swedish and English files
- add missing `innkjop`, `mail`, `nyheter` and `opto` entries
- rename mismatched keys (manual_title, catalog_title etc.)
- placeholders added for untranslated Swedish and English strings

## Testing
- `node - <<'NODE' ...` to verify all files expose 64 identical translation keys
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686d11ac8a40832599f929e09d7f58d1